### PR TITLE
Added ability to pass custom resolver function through to react-docgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ If you pass in a string, `path` should be the relative path from the `gulpfile.j
 
 If you pass in a function, `path` is expected to return a string. The return value can be either a relative from where the generated documentation will be output to the source code, or an absolute path / URL pointing to the source code.
 
+#### resolver
+
+* Type: `function`
+
+A resolver function to pass into react-docgen for identifying React Components from source code. The default resolver recognizes all React Components exported from a module, to supply your own custom resolver function, see the [react-docgen](https://github.com/reactjs/react-docgen) docs for more information.
+
 ## Contributors
 
 - [@marsjosephine](https://github.com/marsjosephine)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = function(options) {
             // get the markdown documentation for the file
             var markdownDoc = reactDocgenMarkdown(file.contents, {
                 componentName   : gUtil.replaceExtension(file.relative, ''),
-                srcLink         : srcLink
+                srcLink         : srcLink,
+                resolver        : options.resolver
             });
             
             // replace the file contents and extension

--- a/src/react-docgen-md.js
+++ b/src/react-docgen-md.js
@@ -63,9 +63,6 @@ Handlebars.registerHelper('whichPartial', function(type) {
     return type && _.contains(partials, type.name) ? type.name : 'catchAll';
 });
 
-Handlebars.registerHelper('name', function(componentName, displayName) {
-  return displayName || componentName;
-});
 /********************************************************
  * General helpers                                      *
  ********************************************************/


### PR DESCRIPTION
Added ability for markdown renderer to handle more than one component per file as some resolver functions may return more than one component per file.

This fixes https://github.com/AdRoll/gulp-react-docs/issues/1, and adds some useful flexibility while preserving the existing behaviour and markdown appearance when using the default resolver function.
