### PR TITLE
POC: enable template overrides

### DIFF
--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -35,7 +35,8 @@ gulp.task('react-docs', function() {
 
     return gulp.src('./components/**/*.jsx')
         .pipe(reactDocsPlugin({
-            path: docsDest
+            path: docsDest,
+            verbose: true,
         }))
         .pipe($.concat('README.md'))
         .pipe($.tap(function(file) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var PLUGIN_NAME = 'gulp-react-docs';
 
 module.exports = function(options) {
     options = options || {};
-    
+
     return through.obj(function(file, encoding, cb) {
         if (file.isNull()) {
             return cb(null, file);
@@ -44,8 +44,8 @@ module.exports = function(options) {
             var markdownDoc = reactDocgenMarkdown(file.contents, {
                 componentName   : gUtil.replaceExtension(file.relative, ''),
                 srcLink         : srcLink
-            });
-            
+            }, options.templates || {});
+
             // replace the file contents and extension
             file.contents = new Buffer(markdownDoc);
             file.path = gUtil.replaceExtension(file.path, '.md');

--- a/index.js
+++ b/index.js
@@ -44,8 +44,10 @@ module.exports = function(options) {
             var markdownDoc = reactDocgenMarkdown(file.contents, {
                 componentName   : gUtil.replaceExtension(file.relative, ''),
                 relativePath    : file.relative,
-                srcLink         : srcLink
-            }, options.templates || {});
+                srcLink         : srcLink,
+                partials        : options.partials || {},
+                helpers         : options.helpers || {},
+            });
 
             // replace the file contents and extension
             file.contents = new Buffer(markdownDoc);

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = function(options) {
             // get the markdown documentation for the file
             var markdownDoc = reactDocgenMarkdown(file.contents, {
                 componentName   : gUtil.replaceExtension(file.relative, ''),
+                relativePath    : file.relative,
                 srcLink         : srcLink
             }, options.templates || {});
 

--- a/src/react-docgen-md.js
+++ b/src/react-docgen-md.js
@@ -14,38 +14,41 @@ var sortObjectByKey = function(obj){
 };
 
 var defaultPartials = {
-    'catchAll', '{{name}}',
-    'func', 'Function',
-    'array', 'Array',
-    'object', 'Object',
-    'string', 'String',
-    'number', 'Number',
-    'bool', 'Boolean',
-    'node', 'ReactNode',
-    'element', 'ReactElement',
-    'any', '*',
-    'custom', '{{raw}} (custom validator)',
-    'arrayOf', '[{{> (whichPartial value) value level=level}}, ...]',
-    'shape', '{\n\
+    'catchAll': '{{name}}',
+    'func': 'Function',
+    'array': 'Array',
+    'object': 'Object',
+    'string': 'String',
+    'number': 'Number',
+    'bool': 'Boolean',
+    'node': 'ReactNode',
+    'element': 'ReactElement',
+    'any': '*',
+    'custom': '{{raw}} (custom validator)',
+    'arrayOf': '[{{> (whichPartial value) value level=level}}, ...]',
+    'shape': '{\n\
 {{#indent level}}\
 {{#each value}}\
     {{@key}}: {{> (whichPartial this) this level=(addLevel ../level)}}\n\
 {{/each}}\n\
 }\
 {{/indent}}',
-    'enum', '(\
+    'enum': '(\
 {{#each value}}\
 {{this.value}}{{#unless @last}}|{{/unless}}\
 {{/each}}\
 )',
-    'union', '(\
+    'union': '(\
 {{#each value}}\
 {{> (whichPartial this) this level=../level}}{{#unless @last}}|{{/unless}}\
 {{/each}}\
 )',
+    'imports': '\
+{{#if srcLink }}From [`{{srcLink}}`]({{srcLink}})\n\n\{{/if}}\
+',
     'document': '\
 ## {{componentName}}\n\n\
-{{#if srcLink }}From [`{{srcLink}}`]({{srcLink}})\n\n\{{/if}}\
+{{> imports }}\
 {{#if description}}{{{description}}}\n\n{{/if}}\
 {{#each props}}\
 #### {{@key}}\n\n\
@@ -66,10 +69,10 @@ var defaultHelpers = {
         ];
         return type && _.contains(partials, type.name) ? type.name : 'catchAll';
     },
-    'addLevel', function(level) {
+    'addLevel': function(level) {
         return level + 1;
     },
-    'indent', function(indentLevel, options) {
+    'indent': function(indentLevel, options) {
         var content = options.fn(this),
             lines = content.split('\n'),
             indentString = '';
@@ -90,13 +93,15 @@ var defaultHelpers = {
  * Documentation generator using react-docgen           *
  ********************************************************/
 
-function loopOverKeys(overrides, defaults, cb) {
-    [].concat(Object.keys(overrides), Object.keys(defaults))
-        .sort()
-        .filter(function (a, b) {
-            return a !== b;
-        })
-        .forEach(cb);
+function merge(defaults, overrides) {
+    var merged = {};
+    Object.keys(defaults).forEach(function (key) {
+        merged[key] = defaults[key];
+    });
+    Object.keys(overrides).forEach(function (key) {
+        merged[key] = overrides[key];
+    });
+    return merged;
 }
 
 var reactDocgenMarkdown = function(componentSrc, options, templates) {
@@ -105,20 +110,30 @@ var reactDocgenMarkdown = function(componentSrc, options, templates) {
     var partialsOverride = templates.partials || {};
     var helpersOverride = templates.helpers || {};
 
-    loopOverKeys(partialsOverride, defaultPartials, function (key) {
-        Handlebars.registerPartial(key, partialsOverride[key] || defaultPartials[key]);
+    var mergedPartials = merge(defaultPartials, partialsOverride);
+    Object.keys(mergedPartials).forEach(function (key) {
+        var override = key in partialsOverride;
+        console.log('compiling partial:', key, ' - ', override ? 'override' : 'default');
+        Handlebars.registerPartial(key, mergedPartials[key]);
     });
 
-    loopOverKeys(helpersOverride, defaultHelpers, function (key) {
-        Handlebars.registerHelper(key, helpersOverride[key] || defaultHelpers[key]);
+    var mergedHelpers = merge(defaultHelpers, helpersOverride);
+    Object.keys(mergedHelpers).forEach(function (key) {
+        var override = key in helpersOverride;
+        console.log('compiling helper:', key, ' - ', override ? 'override' : 'default');
+        Handlebars.registerHelper(key, mergedHelpers[key]);
     });
 
-    var reactDocgenTemplate = Handlebars.compile('{{> document srcLink componentName description props }}');
+    console.log('compiling template: document');
+    var reactDocgenTemplate = Handlebars.compile('{{> document data }}');
     return reactDocgenTemplate({
-        srcLink         : options.srcLink,
-        componentName   : options.componentName,
-        description     : docs.description,
-        props           : sortObjectByKey(docs.props)
+        data: {
+            relativePath    : options.relativePath,
+            srcLink         : options.srcLink,
+            componentName   : options.componentName,
+            description     : docs.description,
+            props           : sortObjectByKey(docs.props)
+        },
     });
 };
 

--- a/src/react-docgen-md.js
+++ b/src/react-docgen-md.js
@@ -107,24 +107,32 @@ function merge(defaults, overrides) {
 var reactDocgenMarkdown = function(componentSrc, options) {
     var docs = reactDocs.parse(componentSrc);
 
+    var verbose = options.verbose || false;
     var partialsOverride = options.partials || {};
     var helpersOverride = options.helpers || {};
+
+    function log() {
+        var args = Array.prototype.slice.apply(arguments);
+        if (verbose) {
+            console.log.apply(console, args);
+        }
+    }
 
     var mergedPartials = merge(defaultPartials, partialsOverride);
     Object.keys(mergedPartials).forEach(function (key) {
         var override = key in partialsOverride;
-        console.log('compiling partial:', key, ' - ', override ? 'override' : 'default');
+        log('compiling partial:', key, ' - ', override ? 'override' : 'default');
         Handlebars.registerPartial(key, mergedPartials[key]);
     });
 
     var mergedHelpers = merge(defaultHelpers, helpersOverride);
     Object.keys(mergedHelpers).forEach(function (key) {
         var override = key in helpersOverride;
-        console.log('compiling helper:', key, ' - ', override ? 'override' : 'default');
+        log('compiling helper:', key, ' - ', override ? 'override' : 'default');
         Handlebars.registerHelper(key, mergedHelpers[key]);
     });
 
-    console.log('compiling template: document');
+    log('compiling template: document');
     var reactDocgenTemplate = Handlebars.compile('{{> document data }}');
     return reactDocgenTemplate({
         data: {

--- a/src/react-docgen-md.js
+++ b/src/react-docgen-md.js
@@ -13,84 +13,37 @@ var sortObjectByKey = function(obj){
     }, {});
 };
 
-/********************************************************
- * Prop type partials and handblebars helpers           *
- ********************************************************/
-
-Handlebars.registerPartial('catchAll', '{{name}}');
-
-// Basic prop types
-Handlebars.registerPartial('func', 'Function');
-Handlebars.registerPartial('array', 'Array');
-Handlebars.registerPartial('object', 'Object');
-Handlebars.registerPartial('string', 'String');
-Handlebars.registerPartial('number', 'Number');
-Handlebars.registerPartial('bool', 'Boolean');
-Handlebars.registerPartial('node', 'ReactNode');
-Handlebars.registerPartial('element', 'ReactElement');
-Handlebars.registerPartial('any', '*');
-Handlebars.registerPartial('custom', '{{raw}} (custom validator)');
-
-// composed prop types
-Handlebars.registerPartial('arrayOf', '[{{> (whichPartial value) value level=level}}, ...]');
-
-Handlebars.registerPartial('shape', '{\n\
+var defaultPartials = {
+    'catchAll', '{{name}}',
+    'func', 'Function',
+    'array', 'Array',
+    'object', 'Object',
+    'string', 'String',
+    'number', 'Number',
+    'bool', 'Boolean',
+    'node', 'ReactNode',
+    'element', 'ReactElement',
+    'any', '*',
+    'custom', '{{raw}} (custom validator)',
+    'arrayOf', '[{{> (whichPartial value) value level=level}}, ...]',
+    'shape', '{\n\
 {{#indent level}}\
 {{#each value}}\
     {{@key}}: {{> (whichPartial this) this level=(addLevel ../level)}}\n\
 {{/each}}\n\
 }\
-{{/indent}}');
-
-Handlebars.registerPartial('enum', '(\
+{{/indent}}',
+    'enum', '(\
 {{#each value}}\
 {{this.value}}{{#unless @last}}|{{/unless}}\
 {{/each}}\
-)');
-
-Handlebars.registerPartial('union', '(\
+)',
+    'union', '(\
 {{#each value}}\
 {{> (whichPartial this) this level=../level}}{{#unless @last}}|{{/unless}}\
 {{/each}}\
-)');
-
-// Partial helper. Tells us which partial to use based on the "propType" name
-Handlebars.registerHelper('whichPartial', function(type) {
-    var partials = [
-        'any', 'array', 'arrayOf', 'bool', 'custom', 'element', 'enum', 'func',
-        'node', 'number', 'object', 'shape', 'string', 'union'
-    ];
-    return type && _.contains(partials, type.name) ? type.name : 'catchAll';
-});
-
-/********************************************************
- * General helpers                                      *
- ********************************************************/
-
-// math helper
-Handlebars.registerHelper('addLevel', function(level) { return level + 1; });
-
-// loop helper
-Handlebars.registerHelper('indent', function(indentLevel, options) {
-    var content = options.fn(this),
-        lines = content.split('\n'),
-        indentString = '';
-
-    // build the indent string we need for this indent level
-    for (var i = 0; i < indentLevel; i++) {
-        indentString += '    ';
-    }
-
-    // add then indents to each line
-    lines = lines.map(function(line) { return line = indentString + line; });
-    return lines.join('\n');
-});
-
-/********************************************************
- * Top-level handlebars template                        *
- ********************************************************/
-
-var reactDocgenTemplate = Handlebars.compile('\
+)',
+    'document': '\
 ## {{componentName}}\n\n\
 {{#if srcLink }}From [`{{srcLink}}`]({{srcLink}})\n\n\{{/if}}\
 {{#if description}}{{{description}}}\n\n{{/if}}\
@@ -103,14 +56,64 @@ var reactDocgenTemplate = Handlebars.compile('\
 ```\n\n\
 {{#if this.description}}{{{this.description}}}\n\n{{/if}}\
 {{/each}}\
-<br><br>\n');
+<br><br>\n',
+};
+var defaultHelpers = {
+    'whichPartial': function(type) {
+        var partials = [
+            'any', 'array', 'arrayOf', 'bool', 'custom', 'element', 'enum', 'func',
+            'node', 'number', 'object', 'shape', 'string', 'union'
+        ];
+        return type && _.contains(partials, type.name) ? type.name : 'catchAll';
+    },
+    'addLevel', function(level) {
+        return level + 1;
+    },
+    'indent', function(indentLevel, options) {
+        var content = options.fn(this),
+            lines = content.split('\n'),
+            indentString = '';
+
+        // build the indent string we need for this indent level
+        for (var i = 0; i < indentLevel; i++) {
+            indentString += '    ';
+        }
+
+        // add then indents to each line
+        lines = lines.map(function(line) { return line = indentString + line; });
+        return lines.join('\n');
+    },
+};
+
 
 /********************************************************
  * Documentation generator using react-docgen           *
  ********************************************************/
 
-var reactDocgenMarkdown = function(componentSrc, options) {
+function loopOverKeys(overrides, defaults, cb) {
+    [].concat(Object.keys(overrides), Object.keys(defaults))
+        .sort()
+        .filter(function (a, b) {
+            return a !== b;
+        })
+        .forEach(cb);
+}
+
+var reactDocgenMarkdown = function(componentSrc, options, templates) {
     var docs = reactDocs.parse(componentSrc);
+
+    var partialsOverride = templates.partials || {};
+    var helpersOverride = templates.helpers || {};
+
+    loopOverKeys(partialsOverride, defaultPartials, function (key) {
+        Handlebars.registerPartial(key, partialsOverride[key] || defaultPartials[key]);
+    });
+
+    loopOverKeys(helpersOverride, defaultHelpers, function (key) {
+        Handlebars.registerHelper(key, helpersOverride[key] || defaultHelpers[key]);
+    });
+
+    var reactDocgenTemplate = Handlebars.compile('{{> document srcLink componentName description props }}');
     return reactDocgenTemplate({
         srcLink         : options.srcLink,
         componentName   : options.componentName,

--- a/src/react-docgen-md.js
+++ b/src/react-docgen-md.js
@@ -104,11 +104,11 @@ function merge(defaults, overrides) {
     return merged;
 }
 
-var reactDocgenMarkdown = function(componentSrc, options, templates) {
+var reactDocgenMarkdown = function(componentSrc, options) {
     var docs = reactDocs.parse(componentSrc);
 
-    var partialsOverride = templates.partials || {};
-    var helpersOverride = templates.helpers || {};
+    var partialsOverride = options.partials || {};
+    var helpersOverride = options.helpers || {};
 
     var mergedPartials = merge(defaultPartials, partialsOverride);
     Object.keys(mergedPartials).forEach(function (key) {


### PR DESCRIPTION
expose both the `partials` and `helpers` property to override the built-in Handlebar templates.

``` js
gulp.task('docs', function() {
  var docsDest = 'docs';
  var r = /^.+\/(.+?)\.jsx?/;

  return gulp.src('./src/**/*.jsx')
    .pipe(reactDocs({
      path: docsDest,
      partials: {
        imports: "import {{parsePath relativePath }} from 'my-module-name'\n\n"
      },
      helpers: {
        parsePath: function(path) {
          return '{ ' + r.exec(path)[1] + ' }';
        }
      },
    }))
    .pipe(gulp.dest(docsDest));
});
```
